### PR TITLE
Ignore error from null STDIN.

### DIFF
--- a/lib/serialport-server/application.rb
+++ b/lib/serialport-server/application.rb
@@ -113,7 +113,7 @@ module SerialportServer
 
         EM::defer do
           loop do
-            line = STDIN.gets.gsub(/[\r\n]/,'')
+            line = STDIN.gets.gsub(/[\r\n]/,'') rescue next
             next if !line or line.to_s.empty?
             @serialport.puts line rescue next
           end


### PR DESCRIPTION
This application causes error when execute in background, as it requires STDIN.  Redirecting STDIN like "</dev/null" does the same.  "rescue next" ignores those errors.
