### PR TITLE
Add binary read functionality to websocket

### DIFF
--- a/lib/serialport-server/application.rb
+++ b/lib/serialport-server/application.rb
@@ -93,6 +93,15 @@ module SerialportServer
               @serialport.puts mes.strip
             end
 
+						# When a binary message is received, write one byte at a time to the serial port.
+						ws.onbinary do |mes|
+							m = mes.unpack('C*')
+
+							puts "* websocket client (BINARY) <#{sid}> : #{mes}"
+							puts "* websocket client (BINARY) <#{sid}> : #{m.join(',')}"
+							m.map{|x| @serialport.putc(x) }
+						end
+
             ws.onclose do
               @channel.unsubscribe sid
               puts "* websocket client <#{sid}> closed"

--- a/lib/serialport-server/version.rb
+++ b/lib/serialport-server/version.rb
@@ -1,3 +1,3 @@
 module SerialportServer
-  VERSION = '0.1.1'
+  VERSION = '0.1.2'
 end


### PR DESCRIPTION
Usage:

In HTML/Javascript:

```javascript
ws = new WebSocket('ws://IP_ADDRESS');
ws.binaryType = "arraybuffer";
var h = [0xfd, 0x01, 0x41, 0x81, 0xc1, 0xfe];
var m = [253, 1, 65, 129, 193, 254];
ws.send(new Uint8Array(h));
```

In serialport-server side,

```sh
$ serialport-server /dev/ttyUSB0
* websocket client (BINARY) <#{sid}> : "ý\u0001A\u0081Áþ"
* websocket client (BINARY) <#{sid}> : 253,1,65,129,193,254
```

Description:

```ruby
$ irb
> h = [0xfd, 0x01, 0x41, 0x81, 0xc1, 0xfe]
> h.pack('U*')
"ý\u0001A\u0081Áþ"
```